### PR TITLE
various README.md updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,6 @@ In addition there is:
 - [Mesh Radio Ireland (N&S) Discord](https://discord.gg/kraQFkpU)
 
 ### USA
-- [West coast Mesh Discord](ttps://discord.gg/wcmesh)
+- [West coast Mesh Discord](https://discord.gg/wcmesh)
 - [nyme.sh Discord](https://discord.nyme.sh/)
 - [CT Mesh Discord](https://discord.gg/m4F328as3K)


### PR DESCRIPTION
Rework Europe section to match North America and Oceania.

Northern Ireland if part of Island of Ireland mesh project so place Meshcore UK under Great Britain (england / wales / scotland)  heading.