### PR TITLE
Added link to meshcore_c, a Portable C99 companion radio library

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ or IoT sensor networks.
 
 | Project Name | Description | First Commit |
 | :--- | :--- | :---: |
+| [meshcore_c](https://github.com/SH3D/meshcore_c) ![GitHub Repo stars](https://img.shields.io/github/stars/SH3D/meshcore_c?style=social) | Portable C99 client library for the MeshCore Companion Radio serial protocol, with an Arduino C++ wrapper. Use on ESP32, nRF52, STM32, or desktop. | Feb 26 |
 | [MeshCoreKmp](https://github.com/Wavesonics/MeshCoreKmp) ![GitHub Repo stars](https://img.shields.io/github/stars/Wavesonics/MeshCoreKmp?style=social) | A Kotlin Multiplatform library for connecting to and communicating with MeshCore companion nodes. | Feb 26 |
 | [Meshcore Client](https://github.com/dz0ny/meshcore_client) ![GitHub Repo stars](https://img.shields.io/github/stars/dz0ny/meshcore_client?style=social) | Flutter/Dart package implementing the MeshCore BLE companion protocol | Feb 26 |
 | [Meshcore Decoder](https://github.com/michaelhart/meshcore-decoder) ![GitHub Repo stars](https://img.shields.io/github/stars/michaelhart/meshcore-decoder?style=social) | A TypeScript library for decoding MeshCore mesh networking packets with full cryptographic support.  | Sep 25  |
@@ -350,6 +351,3 @@ In addition, there are e.g.:
 ### Oceania
  - [Meshore Australia](https://discord.gg/2NxehNDGT)
  - [Canberra Mesh Community](https://discord.gg/YeGhbsWhQD) (ATC and south NSW)
-
-
-


### PR DESCRIPTION
Short one line entry adding reference to new meshcore_c pure C99 library with Arduion wrappers.