### PR TITLE
Add HopRadar to Maps and Diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,6 +162,7 @@ or IoT sensor networks.
 | [meshcoresim.com](https://www.meshcoresim.com/) | Simulation tool for modeling message propagation and testing network scalability. |
 | [map.meshradio.uk](https://map.meshradio.uk/) | Network analysis and visualization tool specifically for the UK MeshRadio community. |
 | [analyzer.letsmesh.net](https://analyzer.letsmesh.net/) | Packet analyzer for debugging MeshCore traces, paths, and real-time network traffic. |
+| [HopRadar](https://hopradar.net/) | Browser-based live map, analyzer & radar using your own node (BLE/USB): hop-by-hop traces with SNR, radio paths, RX radar, LoS coverage and elevation profiles. No install, data stays local. |
 | [meshmapper.net](https://meshmapper.net) | Regionally segmented mapping tool for signal quality and noise floor data. |
 | [map.meshcore.dev](https://map.meshcore.dev/) | Official global map displaying static user uploads for repeaters and room servers. |
 | [m3sh.uk](https://m3sh.uk) | Regional map portal showing the UK network topology as seen from Oxfordshire. |


### PR DESCRIPTION
This PR adds [HopRadar](https://hopradar.net/) to the Maps and Diagnostics section.

HopRadar is a free, browser-based live map & analyzer for MeshCore. Unlike
server-based maps, it connects directly to the user's own node via Web
Bluetooth or USB serial, so it shows the real local mesh as seen by that radio:

- live map of contacts & repeaters (dark/satellite/topo)
- hop-by-hop traces with SNR measurement per hop, animated on the map
- RX radar / live monitor: every overheard packet decoded, routes drawn on the map
- learned radio paths, line-of-sight coverage and elevation profiles with Fresnel zone
- chat & channels, plus a demo mode that works without hardware

Free, no account, non-commercial; all mesh data stays in the browser.